### PR TITLE
Update 2024-04-15 1504H

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -4,6 +4,7 @@
 + [2024-01-03](#2024-01-03)
 + [2024-03-05](#2024-03-05)
 + [2024-03-07](#2024-03-07)
++ [2024-04-15](#2024-04-15)
 
 ## Logs
 ### 2024-01-03
@@ -67,4 +68,36 @@
 - Updates
     - Updated document 'plugins.md'
         + Added list indicators
+
+### 2024-04-15
+#### 1504H
+- New
+    + Added new lua configuration script 'cmp-nvim-lsp.lua' in 'lua/configurations/plugins/' for plugin 'cmp-nvim-lsp'
+    + Added new lua configuration script 'harpoon.lua' in 'lua/configurations/plugins/' for plugin 'harpoon'
+    + Added new lua configuration script 'markdown-preview.lua' in 'lua/configurations/plugins/' for plugin 'markdown-preview'
+    + Added new lua configuration script 'neodev.lua' in 'lua/configurations/plugins/' for plugin 'neodev'
+
+- Updates
+    - Updated lua-language-server LSP plugin configuration file 'lua-language-server.lua' in 'lua/configurations/lsp/'
+        + Fixed setup configuration table and settings key-value mapping
+    - Updated nvim-cmp plugin configuration file 'nvim-cmp.lua' in 'lua/configurations/plugins/'
+        + Added nvim_lua: Neovim lua API autocompletion and documentation
+        + Added sources to cmdline setup
+    - Updated orgmode plugin configuration file 'orgmode.lua' in 'lua/configurations/plugins/'
+        + Removed deprecated function
+    - Updated treesitter plugin configuration file 'treesitter.lua' in 'lua/configurations/plugins/'
+        - Added languages for autoinstallation of treesitter syntaxes
+            + dockerfile
+            + make
+    - Updated lua script 'keybindings.lua' in 'lua/'
+        + Added new keymap/keybinding for opening ':Telescope fd'
+    - Updated lua script 'plugins.lua' in 'lua/'
+        + Added new plugin 'folke/neodev.nvim' : Neovim vim lua API autocompletion and documentations
+        + Added new plugin 'iamcco/markdown-preview.nvim' : Markdown file Previewer
+        + Added new plugin 'ThePrimeagen/harpoon' : The buffer-file finder/jumper
+        + Added comments
+    - Updated lua script 'settings.lua' in 'lua/'
+        + Moved 'HOME' to 'lua/variables.lua'
+    - Updated lua script 'variables.lua' in 'lua/'
+        + Moved 'HOME' from 'lua/settings.lua' as an environment variable
 

--- a/src/lua/configurations/lsp/lua-language-server.lua
+++ b/src/lua/configurations/lsp/lua-language-server.lua
@@ -3,20 +3,23 @@
 -- lua LSP - lua-language-server
 
 -- Prepare other settings
-local table = {
-  settings = {
+local settings_table = {
     Lua = {
+        runtime = {
+            version = "LuaJIT",
+        },
         diagnostics = {
             globals = {'vim'},
         },
         workspace = {
-            library = {
-                [vim.fn.expand("$VIMRUNTIME/lua")] = true,
-                [vim.fn.stdpath("config") .. "/lua"] = true,
-            }
+            library = vim.api.nvim_get_runtime_file("", true),
+            -- {
+            --    [vim.fn.expand("$VIMRUNTIME/lua")] = true,
+            --    [vim.fn.stdpath("config") .. "/lua"] = true,
+            -- },
+            checkThirdParty = false, -- Important: This will stop lua-language-server from prompting for luv (Lunarvim)
         }
     }
-  }
 }
 
 -- Connect to server
@@ -25,5 +28,6 @@ local table = {
 require'lspconfig'.lua_ls.setup {
   capabilities = capabilities,
   on_attach = default_attach,
-  table,
+  settings = settings_table,
 }
+

--- a/src/lua/configurations/plugins/cmp-nvim-lsp.lua
+++ b/src/lua/configurations/plugins/cmp-nvim-lsp.lua
@@ -1,0 +1,9 @@
+-- Settings for
+-- cmp-nvim-lsp : For LSP Autocompletion
+
+-- Set up cmp-nvim-lsp capabilities
+capabilities = require('cmp_nvim_lsp').default_capabilities()
+
+
+
+

--- a/src/lua/configurations/plugins/harpoon.lua
+++ b/src/lua/configurations/plugins/harpoon.lua
@@ -1,0 +1,70 @@
+-- Settings for
+-- harpoon
+--
+-- [Resources]
+-- - https://github.com/ThePrimeagen/harpoon
+
+-- Set up block.lua
+local harpoon = require('harpoon')
+
+-- Setup Harpoon
+harpoon:setup({
+    settings = {
+        save_on_toggle = true,
+        sync_on_ui_close = true,
+    },
+})
+
+harpoon:extend({
+  UI_CREATE = function(cx)
+    vim.keymap.set("n", "<C-v>", function()
+      harpoon.ui:select_menu_item({ vsplit = true })
+    end, { buffer = cx.bufnr })
+
+    vim.keymap.set("n", "<C-x>", function()
+      harpoon.ui:select_menu_item({ split = true })
+    end, { buffer = cx.bufnr })
+
+    vim.keymap.set("n", "<C-t>", function()
+      harpoon.ui:select_menu_item({ tabedit = true })
+    end, { buffer = cx.bufnr })
+  end,
+})
+
+-- Setup basic Telescope configuration for harpoon with Telescope UI
+local conf = require("telescope.config").values
+local function toggle_telescope(harpoon_files)
+    local file_paths = {}
+    for _, item in ipairs(harpoon_files.items) do
+        table.insert(file_paths, item.value)
+    end
+
+    require("telescope.pickers").new({}, {
+        prompt_title = "Harpoon",
+        finder = require("telescope.finders").new_table({
+            results = file_paths,
+        }),
+        previewer = conf.file_previewer({}),
+        sorter = conf.generic_sorter({}),
+    }):find()
+end
+
+-- Set Harpoon Keybindings
+
+--- Harpoon List
+vim.keymap.set("n", "<C-a>", function() harpoon:list():add() end, { desc = "Adds current file into the buffer list" })
+vim.keymap.set("n", "<C-e>", function() harpoon.ui:toggle_quick_menu(harpoon:list()) end)
+--- vim.keymap.set("n", "<C-e>", function() toggle_telescope(harpoon:list()) end, { desc = "Open harpoon window" })
+
+--- Harpoon Index Selection/Jumping
+-- vim.keymap.set("n", "<C-h>", function() harpoon:list():select(1) end, { desc = "Switch to the 1st buffer item"})
+-- vim.keymap.set("n", "<C-t>", function() harpoon:list():select(2) end, { desc = "Switch to the 2nd buffer item"})
+--- vim.keymap.set("n", "<C-n>", function() harpoon:list():select(3) end, { desc = "Switch to the 3rd buffer item"})
+--- vim.keymap.set("n", "<C-s>", function() harpoon:list():select(4) end, { desc = "Switch to the 4th buffer item"})
+
+--- Toggle previous & next buffers stored within Harpoon list
+--- vim.keymap.set("n", "<C-S-P>", function() harpoon:list():prev() end, { desc = "Toggle the previous buffer stored within harpoon's list"})
+--- vim.keymap.set("n", "<C-S-N>", function() harpoon:list():next() end, { desc = "Toggle the next buffer stored within harpoon's list"})
+vim.keymap.set("n", "<C-p>", function() harpoon:list():prev() end, { desc = "Toggle the previous buffer stored within harpoon's list"})
+vim.keymap.set("n", "<C-n>", function() harpoon:list():next() end, { desc = "Toggle the next buffer stored within harpoon's list"})
+

--- a/src/lua/configurations/plugins/markdown-preview.lua
+++ b/src/lua/configurations/plugins/markdown-preview.lua
@@ -1,0 +1,122 @@
+-- Settings for
+-- markdown-preview.nvim
+--
+-- [Resources]
+-- - https://github.com/iamcco/markdown-preview.nvim
+
+-- set to 1, nvim will open the preview window after entering the Markdown buffer
+-- default: 0
+vim.g.mkdp_auto_start = 0
+
+-- set to 1, the nvim will auto close current preview window when changing
+-- from Markdown buffer to another buffer
+-- default: 1
+vim.g.mkdp_auto_close = 1
+
+-- set to 1, Vim will refresh Markdown when saving the buffer or
+-- when leaving insert mode. Default 0 is auto-refresh Markdown as you edit or
+-- move the cursor
+-- default: 0
+vim.g.mkdp_refresh_slow = 0
+
+-- set to 1, the MarkdownPreview command can be used for all files,
+-- by default it can be use in Markdown files only
+-- default: 0
+vim.g.mkdp_command_for_global = 0
+
+-- set to 1, the preview server is available to others in your network.
+-- By default, the server listens on localhost (127.0.0.1)
+-- default: 0
+vim.g.mkdp_open_to_the_world = 0
+
+-- use custom IP to open preview page.
+-- Useful when you work in remote Vim and preview on local browser.
+-- For more details see: https://github.com/iamcco/markdown-preview.nvim/pull/9
+-- default empty
+-- Default: vim.g.mkdp_open_ip = ''
+vim.g.mkdp_open_ip = '127.0.0.1'
+
+-- specify browser to open preview page
+-- for path with space
+-- valid: `/path/with\ space/xxx`
+-- invalid: `/path/with\\ space/xxx`
+-- default: ''
+-- Default: vim.g.mkdp_browser = ''
+vim.g.mkdp_browser = 'chrome'
+
+-- set to 1, echo preview page URL in command line when opening preview page
+-- default is 0
+-- Default: vim.g.mkdp_echo_preview_url = 0
+vim.g.mkdp_echo_preview_url = 1
+
+-- a custom Vim function name to open preview page
+-- this function will receive URL as param
+-- default is empty
+vim.g.mkdp_browserfunc = ''
+
+-- options for Markdown rendering
+-- mkit: markdown-it options for rendering
+-- katex: KaTeX options for math
+-- uml: markdown-it-plantuml options
+-- maid: mermaid options
+-- disable_sync_scroll: whether to disable sync scroll, default 0
+-- sync_scroll_type: 'middle', 'top' or 'relative', default value is 'middle'
+--   middle: means the cursor position is always at the middle of the preview page
+--   top: means the Vim top viewport always shows up at the top of the preview page
+--   relative: means the cursor position is always at relative positon of the preview page
+-- hide_yaml_meta: whether to hide YAML metadata, default is 1
+-- sequence_diagrams: js-sequence-diagrams options
+-- content_editable: if enable content editable for preview page, default: v:false
+-- disable_filename: if disable filename header for preview page, default: 0
+vim.g.mkdp_preview_options = {
+    mkit = {},
+    katex = {},
+    uml = {},
+    maid = {},
+    disable_sync_scroll = 0,
+    sync_scroll_type = 'middle',
+    hide_yaml_meta = 1,
+    sequence_diagrams = {},
+    flowchart_diagrams = {},
+    content_editable = false,
+    disable_filename = 0,
+    toc = {}
+}
+
+-- use a custom Markdown style. Must be an absolute path
+-- like '/Users/username/markdown.css' or expand('~/markdown.css')
+vim.g.mkdp_markdown_css = ''
+
+-- use a custom highlight style. Must be an absolute path
+-- like '/Users/username/highlight.css' or expand('~/highlight.css')
+vim.g.mkdp_highlight_css = ''
+
+-- use a custom port to start server or empty for random
+-- Default: vim.g.mkdp_port = ''
+vim.g.mkdp_port = '8080'
+
+-- preview page title
+-- ${name} will be replace with the file name
+vim.g.mkdp_page_title = '「${name}」'
+
+-- use a custom location for images
+-- Default: vim.g.mkdp_images_path = "/home/user/.markdown_images"
+
+-- recognized filetypes
+-- these filetypes will have MarkdownPreview... commands
+vim.g.mkdp_filetypes = {'markdown'}
+
+-- set default theme (dark or light)
+-- By default the theme is defined according to the preferences of the system
+vim.g.mkdp_theme = 'dark'
+
+-- combine preview window
+-- default: 0
+-- if enable it will reuse previous opened preview window when you preview markdown file.
+-- ensure to set vim.g.mkdp_auto_close = 0 if you have enable this option
+vim.g.mkdp_combine_preview = 0
+
+-- auto refetch combine preview contents when change markdown buffer
+-- only when g:mkdp_combine_preview is 1
+vim.g.mkdp_combine_preview_auto_refresh = 1
+

--- a/src/lua/configurations/plugins/neodev.lua
+++ b/src/lua/configurations/plugins/neodev.lua
@@ -1,0 +1,41 @@
+-- Settings for
+-- folke/neodev : Neovim Lua API autocompletion and documentations
+--
+-- [Resources]
+-- - https://github.com/folke/neodev.nvim
+
+-- Import plugin library/package
+local neodev = require("neodev")
+
+-- Initialize Local Variables
+local defaults = {
+  library = {
+    enabled = true, -- when not enabled, neodev will not change any settings to the LSP server
+    -- these settings will be used for your Neovim config directory
+    runtime = true, -- runtime path
+    types = true, -- full signature, docs and completion of vim.api, vim.treesitter, vim.lsp and others
+    plugins = true, -- installed opt or start plugins in packpath
+    -- you can also specify the list of plugins to make available as a workspace library
+    -- plugins = { "nvim-treesitter", "plenary.nvim", "telescope.nvim" },
+  },
+  setup_jsonls = true, -- configures jsonls to provide completion for project specific .luarc.json files
+  -- for your Neovim config directory, the config.library settings will be used as is
+  -- for plugin directories (root_dirs having a /lua directory), config.library.plugins will be disabled
+  -- for any other directory, config.library.enabled will be set to false
+  override = function(root_dir, options) end,
+  -- With lspconfig, Neodev will automatically setup your lua-language-server
+  -- If you disable this, then you have to set {before_init=require("neodev.lsp").before_init}
+  -- in your lsp start options
+  lspconfig = true,
+  -- much faster, but needs a recent built of lua-language-server
+  -- needs lua-language-server >= 3.6.0
+  pathStrict = true,
+}
+
+-- IMPORTANT: make sure to setup neodev BEFORE lspconfig
+neodev.setup({
+  -- add any options here, or leave empty to use the default settings
+  defaults
+})
+
+

--- a/src/lua/configurations/plugins/nvim-cmp.lua
+++ b/src/lua/configurations/plugins/nvim-cmp.lua
@@ -72,12 +72,12 @@ cmp.setup({
     ['<CR>'] = cmp.mapping.confirm({ select = true }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
   }),
   sources = cmp.config.sources({
-    { name = 'nvim_lsp' },
+    { name = 'nvim_lsp' }, -- For nvim-lsp
+    { name = 'nvim_lua' }, -- For nvim lua API LSP
     -- { name = 'vsnip' }, -- For vsnip users.
     { name = 'luasnip' }, -- For luasnip users.
     -- { name = 'ultisnips' }, -- For ultisnips users.
     -- { name = 'snippy' }, -- For snippy users.
-  }, {
     { name = 'buffer' },
   }), {
     { name = 'orgmode'}
@@ -113,7 +113,8 @@ cmp.setup.filetype('gitcommit', {
 cmp.setup.cmdline({ '/', '?' }, {
   mapping = cmp.mapping.preset.cmdline(),
   sources = {
-    { name = 'buffer' }
+    { name = 'buffer' },
+    { name = 'path' }
   }
 })
 
@@ -135,9 +136,9 @@ lsp_defaults.capabilities = vim.tbl_deep_extend(
     'force',
     lsp_defaults.capabilities,
     require('cmp_nvim_lsp').default_capabilities()
-    --- capabilities = require('cmp_nvim_lsp').default_capabilities()
 )
 -- Replace <YOUR_LSP_SERVER> with each lsp server you've enabled.
 --require('lspconfig')['<YOUR_LSP_SERVER>'].setup {
 --  capabilities = capabilities
 --}
+

--- a/src/lua/configurations/plugins/orgmode.lua
+++ b/src/lua/configurations/plugins/orgmode.lua
@@ -17,7 +17,7 @@ local work = notes .. "/work";
 local home = notes .. "/home";
 
 --- Load custom treesitter grammar for org filetype
-orgmode.setup_ts_grammar()
+--- Deprecated: orgmode.setup_ts_grammar()
 
 --- Orgmode setup
 orgmode.setup({

--- a/src/lua/configurations/plugins/treesitter.lua
+++ b/src/lua/configurations/plugins/treesitter.lua
@@ -7,7 +7,7 @@ treesitter_cfgs.setup {
     --- Treesitter Configurations
 
     -- Ensure that the following Treesitter languages are installed; Equivalent to running ':TSUpdate [language]'
-    ensure_installed = {'bash', 'c', 'cpp', 'java', 'javascript', 'lua', 'markdown', 'nix', 'org', 'python', 'query', 'rust', 'sql', 'vim', 'vimdoc', 'yaml'},
+    ensure_installed = {'bash', 'c', 'cpp', 'java', 'javascript', 'lua', 'markdown', 'nix', 'org', 'python', 'query', 'rust', 'sql', 'vim', 'vimdoc', 'yaml', 'dockerfile', 'make'},
 
     -- Install parsers synchronously (only applied to 'ensure_installed')
     sync_install = false,

--- a/src/lua/keybindings.lua
+++ b/src/lua/keybindings.lua
@@ -5,4 +5,4 @@
 -- Setting Keybindings:
 -- vim.keymap.set('<mode (n|v|i)>', '<keybind>', '<command>', {option-keys=values})
 vim.keymap.set('n', "<leader>e", "<Cmd>NvimTreeToggle<CR>", {silent=true}) -- Set nvim-tree toggle on '<leader>-e' keypress
-
+vim.keymap.set('n', "<leader>f", "<Cmd>Telescope fd<CR>", {silent=true, desc="Open Telescope fd Fuzzy File searcher"})

--- a/src/lua/plugins.lua
+++ b/src/lua/plugins.lua
@@ -86,7 +86,7 @@ plugins = {
         config = function()
             require'configurations.plugins.treesitter'
         end
-    }, 
+    },
     'andymass/vim-matchup', --- Matching parenthesis, brackets etc.
     'bronson/vim-trailing-whitespace', --- Highlight trailing spaces
     'scrooloose/nerdcommenter', -- Commenting shortcuts
@@ -141,6 +141,15 @@ plugins = {
         end
     },
 
+    --- Lua configurations
+    {
+        'folke/neodev.nvim',
+        opts = {},
+        config = function()
+            require'configurations.plugins.neodev'
+        end
+    },
+
     --- Native LSP
     {
         'neovim/nvim-lspconfig', --- Neovim Lua LSP integration configuration
@@ -151,14 +160,15 @@ plugins = {
     'glepnir/lspsaga.nvim', --- LSP plugin for highly performant UI features
 
     --- LSP Autocomplete
-    {'hrsh7th/nvim-cmp',
+    {
+        'hrsh7th/nvim-cmp',
         config = function()
             require'configurations.plugins.nvim-cmp'
         end
     }, --- Neovim Lua LSP Autocompletion engine
-    'hrsh7th/cmp-nvim-lsp',
-    'hrsh7th/cmp-buffer',
-    'hrsh7th/cmp-path',
+    'hrsh7th/cmp-nvim-lsp', --- Neovim Lua vim API LSP server
+    'hrsh7th/cmp-buffer',   --- nvim-cmp autocompletion via buffer support
+    'hrsh7th/cmp-path',     --- nvim-cmp autocompletion via path support
 
     --- UNIX support
     'tpope/vim-eunuch', --- UNIX shell command wrapper
@@ -172,10 +182,28 @@ plugins = {
             require'configurations.plugins.glow'
         end
     },
+    {
+        "iamcco/markdown-preview.nvim",
+        cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
+        ft = { "markdown" },
+        -- build = function() vim.fn["mkdp#util#install"]() end,
+        build = "cd app && npm install",
+        config = function()
+            require'configurations.plugins.markdown-preview'
+        end
+    },
 
     --- Buffer Navigation/Status line/bar
     'vim-airline/vim-airline', --- Status bar
     'vim-airline/vim-airline-themes', --- Themes for the status bar/statusline 'vim-airline'
+    {
+        "ThePrimeagen/harpoon",
+        branch = "harpoon2",
+        dependencies = { "nvim-lua/plenary.nvim" },
+        config = function()
+            require('configurations.plugins.harpoon')
+        end
+    }, --- Harpoon: Buffer fuzzy finder/jumper
 
     --- Telescope Requirements/Dependencies
     {'nvim-telescope/telescope.nvim', dependencies={{'nvim-lua/popup.nvim'}, {'nvim-lua/plenary.nvim'}},}, -- Fuzzy file finder for Neovim written in Lua

--- a/src/lua/settings.lua
+++ b/src/lua/settings.lua
@@ -4,8 +4,6 @@
 -- vim.o = vim.opt = Vim Options
 -- vim.cmd = Vim commands
 
-HOME = os.getenv("HOME")
-
 -- Global Variables
 vim.g.mapleader = "," -- variable represents <leader>
 vim.g.maplocalleader = "\\"

--- a/src/lua/variables.lua
+++ b/src/lua/variables.lua
@@ -9,4 +9,6 @@ fn = vim.fn
 nvim_data = fn.stdpath('data')
 nvim_config = fn.stdpath('config')
 
+--- Environment Variables
+HOME = os.getenv("HOME")
 


### PR DESCRIPTION
- New
    + Added new lua configuration script 'cmp-nvim-lsp.lua' in 'lua/configurations/plugins/' for plugin 'cmp-nvim-lsp'
    + Added new lua configuration script 'harpoon.lua' in 'lua/configurations/plugins/' for plugin 'harpoon'
    + Added new lua configuration script 'markdown-preview.lua' in 'lua/configurations/plugins/' for plugin 'markdown-preview'
    + Added new lua configuration script 'neodev.lua' in 'lua/configurations/plugins/' for plugin 'neodev'

- Updates
    - Updated lua-language-server LSP plugin configuration file 'lua-language-server.lua' in 'lua/configurations/lsp/'
        + Fixed setup configuration table and settings key-value mapping
    - Updated nvim-cmp plugin configuration file 'nvim-cmp.lua' in 'lua/configurations/plugins/'
        + Added nvim_lua: Neovim lua API autocompletion and documentation
        + Added sources to cmdline setup
    - Updated orgmode plugin configuration file 'orgmode.lua' in 'lua/configurations/plugins/'
        + Removed deprecated function
    - Updated treesitter plugin configuration file 'treesitter.lua' in 'lua/configurations/plugins/'
        - Added languages for autoinstallation of treesitter syntaxes
            + dockerfile
            + make
    - Updated lua script 'keybindings.lua' in 'lua/'
        + Added new keymap/keybinding for opening ':Telescope fd'
    - Updated lua script 'plugins.lua' in 'lua/'
        + Added new plugin 'folke/neodev.nvim' : Neovim vim lua API autocompletion and documentations
        + Added new plugin 'iamcco/markdown-preview.nvim' : Markdown file Previewer
        + Added new plugin 'ThePrimeagen/harpoon' : The buffer-file finder/jumper
        + Added comments
    - Updated lua script 'settings.lua' in 'lua/'
        + Moved 'HOME' to 'lua/variables.lua'
    - Updated lua script 'variables.lua' in 'lua/'
        + Moved 'HOME' from 'lua/settings.lua' as an environment variable
